### PR TITLE
Use default to require turf pointToLineDistance

### DIFF
--- a/lib/labels/index.js
+++ b/lib/labels/index.js
@@ -1,7 +1,7 @@
 const {chain} = require('lodash')
 const length = require('@turf/length')
 const lineSlice = require('@turf/line-slice')
-const pointToLineDistance = require('@turf/point-to-line-distance')
+const pointToLineDistance = require('@turf/point-to-line-distance').default
 const {getRelatedObjects} = require('../topology/relations')
 
 function getRawLabels(featureId, ctx) {


### PR DESCRIPTION
I get the following error when parsing an edigeo sheet.
```javascript
TypeError: pointToLineDistance is not a function
```
turf now use `exports.default` and must be import with`const pointToLineDistance = require('point-to-line-distance').default`