### PR TITLE
Add layer names and feature count for each

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,6 +6,9 @@ async function doStuff() {
   const buf = await getStdin.buffer()
   const {layers} = await parse(buf)
   console.log('Found %d layers!', Object.keys(layers).length)
+  for (const [key, value] of Object.entries(layers)) {
+    console.log(`Layer name ${key}: ${value.length}`);
+  }
 }
 
 doStuff().catch(error => {


### PR DESCRIPTION
Instead of getting the following with command `cat /tmp/edigeo-051620000A01.tar.bz2 | edigeo-parse`

```
Objet_20176(COMMUNE) => geometry ignored (ring-has-duplicate-vertices, has-self-intersection)
Objet_1313013(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_1313014(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_2878858(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_3066768(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_963975(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Impossible de relier la subdivision fiscale à sa parcelle
Found 15 layers!
```

Now, you can get

```
Objet_20176(COMMUNE) => geometry ignored (ring-has-duplicate-vertices, has-self-intersection)
Objet_1313013(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_1313014(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_2878858(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_3066768(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Objet_963975(TLINE) => geometry ignored (Too many linked arcs to build a single LineString)
Impossible de relier la subdivision fiscale à sa parcelle
Found 15 layers!
Layer name PARCELLE: 496
Layer name LABEL: 562
Layer name SUBDSECT: 1
Layer name SECTION: 1
Layer name TLINE: 137
Layer name LIEUDIT: 3
Layer name TRONFLUV: 37
Layer name ZONCOMMUNI: 7
Layer name SUBDFISC: 26
Layer name TPOINT: 6
Layer name TSURF: 25
Layer name BORNE: 12
Layer name BATIMENT: 86
Layer name SYMBLIM: 10
Layer name CROIX: 1
```

This change is to be able to compare with GDAL output as some communes are not parsed correctly (as least for the commune polygon) e.g https://gist.github.com/ThomasG77/f75f50356d50b9e428dc01c076f6574a