### PR TITLE
POC debug discussion

### DIFF
--- a/lib/assemble/geometry/index.js
+++ b/lib/assemble/geometry/index.js
@@ -23,7 +23,8 @@ function buildPolygon(fea, ctx) {
       'No exterior ring found',
       'Topology not supported yet',
     ].includes(error.message)) {
-      throw new Error('Unable to build valid polygon coordinates')
+      //console.log(error, faces)
+      throw new Error(error.message + '. Unable to build valid polygon coordinates')
     }
 
     throw error
@@ -48,7 +49,23 @@ function buildMultiPolygon(fea, ctx) {
       'No exterior ring found',
       'Topology not supported yet',
     ].includes(error.message)) {
-      throw new Error('Unable to build valid polygon coordinates')
+      throw new Error(error.message + '. Unable to build valid polygon coordinates in multipolygon. ' + 'Feature id: ' + fea.fullId + '. GeoJSON arcs: ' + JSON.stringify({
+        "type": "FeatureCollection",
+        "features": faces[0].arcs.map(arc => {
+          return {
+            "type": "Feature",
+            "properties": {
+              id: arc.id,
+              fullId: arc.fullId,
+              ns: arc.ns
+            },
+            "geometry": {
+              "type": "LineString",
+              "coordinates": arc.coordinates
+            }
+          }
+        })
+      }))
     }
 
     throw error


### PR DESCRIPTION
The intend is to find out the best way to debug issues related to edigeo format parsing.
At the moment, when running it, it outputs something like below

```
395110000U01:Objet_1314984(SECTION) => geometry ignored (Unable to build valid polygon coordinates)
```

The changes made the output the following

```
Objet_1314984(SECTION) => geometry ignored (Unable to close the current ring: no more arcs available. Unable to build valid polygon coordinates in multipolygon. Feature id: SeSPA_1:Objet_1314984. GeoJSON arcs: {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"id":"SeSPA_1:Arc_1314984_1","fullId":"SeSPA_1:Arc_1314984_1","ns":"SeSPA_1"},"geometry":{"type":"LineString","coordinates":[[887800.53,6645617.44],[887818.1,6645641.99],[887844.76,6645676.24],[887883.01,6645721.65],[887908.43,6645734.86],[887947.93,6645751.09],[887957.4,6645755.43],[887961.39,6645757.52],[887962.13,6645758.12],[887963.09,6645758.98],[887964.1,6645760.53],[887969.56,6645768.79],[887974.9,6645786.11],[887977.3,6645792.64],[887981.09,6645798.6],[887986.99,6645806.37],[888009.27,6645831.93],[888010.89,6645833.61],[888037.55,6645860.35],[888037.8,6645860.59],[888094.12,6645885.66],[888109.44,6645893.71],[888121.17,6645903.32],[888121.47,6645903.7],[888125.85,6645906.81],[888127.1,6645908.83],[888151.06,6645944.44],[888151.13,6645944.54],[888153.21,6645947.93],[888175.98,6645979.33],[888213.4,6646031.69],[888217.41,6646038.16],[888217.49,6646038.28],[888220.98,6646043.99],[888222.56,6646047.09],[888226.08,6646056.48],[888231.69,6646080.93],[888231.75,6646081.17],[888233.14,6646082.11],[888233.32,6646082.24],[888233.76,6646082.53],[888235,6646091.5],[888242.33,6646180.35],[888242.12,6646186.1],[888242.04,6646188.82],[888236.85,6646254.55],[888236.66,6646255.55],[888236.62,6646255.79],[888227.67,6646304.9],[888227.24,6646306.27],[888225.34,6646312.37],[888192.13,6646444.13],[888191.35,6646447],[888191.25,6646447.39],[888174.33,6646510.28],[888159.14,6646534.4],[888158.81,6646534.92],[888157.34,6646543.36],[888157.02,6646545.27],[888145.58,6646600.53],[888117.65,6646697.99],[888106.34,6646787.37],[888037.03,6646799.15],[887944.98,6646815.37],[887919.23,6646819.72],[887910.52,6646821.17],[887864.45,6646828.99],[887804.18,6646838.77],[887779.53,6646843.09],[887723.95,6646852.44],[887694.24,6646857.93],[887654.38,6646847.75],[887606.98,6646835.3],[887558.42,6646834.76],[887544.62,6646834.61],[887467.69,6646834.42],[887453.54,6646835],[887414.5,6646841.79],[887321.6,6646858.39],[887300.21,6646862.35],[887290.69,6646864.27],[887280.39,6646866.46],[887275.36,6646867.58],[887247,6646874.64],[887198.75,6646885.92],[887184.82,6646879.14],[887162.86,6646868.17],[887150.89,6646862.44],[887140.88,6646857.62],[887073.61,6646824.43],[887062.95,6646819.24],[887021.6,6646799.31],[886993.99,6646805.24],[886940.01,6646816.5],[886889.55,6646826.96],[886881.31,6646828.66],[886864.47,6646832.09],[886746.39,6646855.53],[886738.92,6646856.99],[886719.38,6646860.83],[886674.4,6646869.88],[886673.49,6646866.45],[886663.41,6646828.36],[886662.32,6646784.53],[886670.02,6646777.83],[886733.73,6646782.83],[886732.62,6646775.82],[886736.5,6646774.85],[886739.71,6646774.03],[886748.15,6646771.72],[886849.56,6646721.47],[886882.14,6646701.75],[886917.84,6646675.38],[886959.28,6646634.89],[886977.73,6646621.26],[886982.97,6646607.48],[886988.85,6646610.09],[886989.09,6646610.2],[886991,6646614.85],[887018.73,6646682.17],[887031,6646721.03],[887033.73,6646720.25],[887058.91,6646713.13],[887060.66,6646711.97],[887087.85,6646693.79],[887091.42,6646692.26],[887098.37,6646689.25],[887115.21,6646688.51],[887118.48,6646686.45],[887127.03,6646681.11],[887137.29,6646674.68],[887152.74,6646665],[887150.41,6646649.38],[887145.86,6646618.9],[887140.66,6646584],[887139.85,6646582.6],[887139.34,6646581.71],[887130.93,6646567.21],[887117.33,6646543.75],[887101.09,6646515.71],[887147.82,6646478.71],[887148.37,6646477.71],[887206.31,6646370.03],[887224.88,6646359.54],[887225.07,6646359.45],[887227.74,6646358.23],[887228.24,6646357.95],[887232.66,6646355.42],[887246.97,6646347.23],[887261.74,6646369.3],[887291.53,6646354.95],[887354.24,6646324.75],[887354.44,6646324.64],[887362.92,6646320.23],[887381.24,6646349.52],[887381.92,6646350.21],[887396.25,6646364.66],[887480.53,6646325.68],[887484.99,6646323.62],[887533.29,6646308.09],[887534.29,6646307.61],[887540.52,6646304.7],[887552.14,6646299.27],[887553.09,6646298.83],[887579.13,6646286.67],[887597.44,6646327.56],[887597.52,6646333.35],[887597.77,6646352.93],[887597.9,6646362.44],[887597.94,6646365.3],[887599.67,6646383.74],[887601.09,6646398.77],[887612.81,6646415.45],[887615.99,6646414.65],[887676.41,6646399.3],[887697.13,6646401.33],[887697.71,6646401.4],[887707.28,6646402.34],[887721.24,6646403.7],[887721,6646400.32],[887718.67,6646368.95],[887717.27,6646366.1],[887713.66,6646358.75],[887701.97,6646334.99],[887696.89,6646321.48],[887690.05,6646303.32],[887688.18,6646276.94],[887688.21,6646274.44],[887688.34,6646263.56],[887693.94,6646251.64],[887696.1,6646248.56],[887700.17,6646244.1],[887743.15,6646197.16],[887744.27,6646195.04],[887744.48,6646194.64],[887783.45,6646120.55],[887783.35,6646118.98],[887780.08,6646070.91],[887778.68,6646071.69],[887755.06,6646084.78],[887753.31,6646086.35],[887719.92,6646116.39],[887694.35,6646128.75],[887684.22,6646130.79],[887668.35,6646133.99],[887662.25,6646133.89],[887626.11,6646133.29],[887652.71,6646119.87],[887693.55,6646099.3],[887710.92,6646090.85],[887777.21,6646058.59],[887777.4,6646058.47],[887780.79,6646056.15],[887774.48,6646035.55],[887769.06,6646022.3],[887762.48,6646008.27],[887762.12,6645997.38],[887761.5,6645992.84],[887755.63,6645978.81],[887747.41,6645961.17],[887735.33,6645940.58],[887726.49,6645925.09],[887712.53,6645894.21],[887709.46,6645887.47],[887708.61,6645885.85],[887693.08,6645861.91],[887692,6645860.01],[887688.74,6645852.64],[887686.35,6645845.51],[887681.06,6645823.8],[887680.73,6645823.19],[887670.28,6645801.65],[887667.52,6645787.91],[887667.51,6645787.4],[887667.46,6645787.24],[887666.57,6645783.3],[887657.78,6645770.79],[887652.33,6645760.76],[887651.51,6645759.12],[887645.49,6645747.02],[887645.25,6645744.46],[887643.88,6645729.89],[887652.3,6645722.48],[887678.99,6645708.59],[887683.52,6645705.31],[887696.29,6645695.85],[887753.46,6645650.39],[887777.15,6645633.04],[887792.63,6645618.04],[887800.53,6645617.44]]}},{"type":"Feature","properties":{"id":"SeSPA_1:Arc_1314984_2","fullId":"SeSPA_1:Arc_1314984_2","ns":"SeSPA_1"},"geometry":{"type":"LineString","coordinates":[[887792.63,6645618.04],[887791.98,6645618],[887773.91,6645614.9],[887767.91,6645613.45],[887767.62,6645613.39],[887749.59,6645607.96],[887742.51,6645605.71],[887741.96,6645605.54],[887722.85,6645599.49],[887672.05,6645583.4],[887661.68,6645577.72],[887653.05,6645579.98],[887634.37,6645551.75],[887628.94,6645548.9],[887585.23,6645523.7],[887580.38,6645521.15],[887558.69,6645509.77],[887546.75,6645503.51],[887543.05,6645501.57],[887533.48,6645496.55],[887520.93,6645494.57],[887511.52,6645493.1],[887504.02,6645490.27],[887479.28,6645481],[887455.03,6645485.25],[887450.29,6645486.08],[887440.55,6645484.12],[887424.62,6645480.71],[887408.1,6645438.53],[887408.52,6645435.02],[887410.13,6645421.59],[887410.15,6645421.42],[887412.84,6645418.83],[887423.76,6645408.28],[887424.45,6645398.23],[887425.02,6645390.18],[887425.14,6645388.49],[887425.34,6645385.59],[887423.21,6645378.87],[887423.17,6645378.75],[887419.88,6645373.41],[887417.25,6645369.13],[887417.16,6645368.98],[887409.82,6645329.53],[887416.67,6645309.33],[887418.56,6645302.89],[887407.36,6645299.94],[887402.97,6645299.81],[887399.08,6645300.13],[887391.63,6645300.75],[887390.23,6645293.64],[887395.41,6645290.18],[887395.85,6645289.88],[887407.87,6645268.62],[887383.98,6645235.49],[887471.45,6645189.07],[887539.96,6645154.57],[887570.47,6645140.93],[887650.66,6645104.2],[887661.39,6645099.24],[887678.88,6645091.43],[887699.93,6645089.03],[887708.03,6645071.3],[887716.73,6645065.94],[887736.93,6645008.17],[887744.3,6645004.16],[887750.25,6645002.78],[887758.06,6644995.35],[887764.68,6644988.62],[887782.66,6644998.36],[887813.81,6645006.98],[887824.4,6645013.62],[887851.84,6645004.39],[887871.47,6644994.3],[887878.17,6644990.58],[887914.33,6644967.17],[887939.07,6644960.94],[888012.75,6644956.51],[888035.78,6644952.78],[888084.55,6644966.83],[888094.55,6644969.79],[888093.83,6644971.11],[888093.06,6644972.52],[888093.67,6644972.81],[888094.14,6644973.04],[888109.76,6644980.75],[888110.06,6644982.98],[888113,6645005.04],[888113.05,6645005.5],[888111.22,6645006.34],[888099.4,6645011.68],[888085.87,6645017.78],[888074.84,6645022.75],[888054.97,6645031.72],[888052.57,6645032.81],[888038.49,6645028.12],[888031.88,6645025.91],[888026.76,6645024.2],[888017.58,6645021.15],[888015.94,6645020.6],[888015.53,6645020.54],[888000.6,6645018.33],[887982.93,6645015.71],[887982.46,6645015.63],[887948.09,6645027.78],[887879.34,6645063.07],[887843.27,6645086.57],[887838.81,6645095],[887838.89,6645095.5],[887840.51,6645105.09],[887843.61,6645123.52],[887844.51,6645128.87],[887845.12,6645132.51],[887845.62,6645135.45],[887844.53,6645136.22],[887829.51,6645146.94],[887818.04,6645155.11],[887808.64,6645154.56],[887798.38,6645160.12],[887788.7,6645165.35],[887786.04,6645166.79],[887754.15,6645193.04],[887754.69,6645193.58],[887818.93,6645258.25],[887822.28,6645261.37],[887822.77,6645261.83],[887739.55,6645315.09],[887739.67,6645315.27],[887741.97,6645318.78],[887746.89,6645320.91],[887748.17,6645328.18],[887757.35,6645380.51],[887778.11,6645438.97],[887798.87,6645510.45],[887800.65,6645514.09],[887812.38,6645538.06],[887814.01,6645541.38],[887821.41,6645538.75],[887841.62,6645531.03],[887842.82,6645530.75],[887843.03,6645530.7],[887849.39,6645529.24],[887884.29,6645519.28],[887888.44,6645517.74],[887934.81,6645500.49],[887934.93,6645499.8],[887935.29,6645497.63],[887936.07,6645493.03],[887935.87,6645492.53],[887935.21,6645490.9],[887933.8,6645487.39],[887914,6645437.98],[887964.18,6645419.37],[887964.35,6645419.64],[887973.28,6645433.37],[887975.92,6645437.44],[887986.9,6645454.35],[887986.98,6645454.44],[887991.51,6645460.44],[888014.87,6645491.27],[888022.41,6645501.24],[888035.76,6645518.85],[888037.32,6645524.51],[888037.95,6645526.76],[888018.1,6645529.56],[887991.11,6645535.35],[887948.59,6645544.26],[887942.9,6645546.23],[887919.15,6645557],[887876.91,6645577.67],[887811.25,6645611.76],[887808.8,6645613.03],[887801.02,6645617],[887800.53,6645617.44]]}}]})
```

The output is the excerpt from running `./bin/cli.js < edigeo-395110000U01.tar.bz2` where the file was obtained with `wget https://cadastre.data.gouv.fr/data/dgfip-pci-vecteur/2022-07-01/edigeo/feuilles/39/39511/edigeo-395110000U01.tar.bz2`

The questions are:
- should it be better to separate output for debugging from the main messages (the one before my changes) due to issues?
- should I write somewhere the specific part added like the GeoJSON features?

Then, when decided, I will apply the same rules for other types of errors (here only one specific case)
